### PR TITLE
Improve jshint settings

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,5 +1,0 @@
-node_modules/
-test/
-build/
-bower_components/
-Gruntfile.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,8 @@ module.exports = function(grunt) {
     jshint: {
       files: ['<%= pkg.name %>.js', 'package.json'],
       options: {
-        jshintrc: '.jshintrc'
+        jshintrc: '.jshintrc',
+        src: ['lazyload.js', 'Gruntfile.js']
       }
     }
   });


### PR DESCRIPTION
- Use `src`.
- Remove `.jshintignore`.
- Lint `Gruntfile.js` also.
