### PR TITLE
add onVisible callback

### DIFF
--- a/lazyload.js
+++ b/lazyload.js
@@ -29,7 +29,8 @@
     opts = merge({
       'offset': 333,
       'src': 'data-src',
-      'container': false
+      'container': false,
+      'onVisible': null
     }, opts || {});
 
     if (typeof opts['src'] === 'string') {
@@ -43,6 +44,9 @@
 
       if (src) {
         elt.src = src;
+        if(typeof opts.onVisible === 'function'){
+            opts.onVisible(elt);
+        }
       }
 
       elt['data-lzled'] = true;


### PR DESCRIPTION
add onVisible callback
callback will be called when the element in viewport

it's useful to extend functionally outside.
like this example in my project, I can do anything i want on 'elem'
```
window['lazyshow'] = lazyload({onVisible: function(elem){
            $(elem).addClass('fadeIn');
        }})```
