### PR TITLE
Decitre uses vvo/lazyload

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Tens of millions of pageviews are served each month using this project:
 * [clubic.com](http://clubic.com)
 * [achetezfacile.com](http://www.achetezfacile.com/)
 * [mapado.com](http://www.mapado.com/)
+* [decitre.fr](http://www.decitre.fr/)
+* [base-orb.fr](http://www.base-orb.fr/)
 
 .. And many unlisted websites, [add yours](https://github.com/vvo/lazyload/edit/master/README.md)!
 


### PR DESCRIPTION
* used on www.decitre.fr
* used on www.base-orb.fr